### PR TITLE
apiVersion controls HTTP header, not media type.

### DIFF
--- a/test/Query.hs
+++ b/test/Query.hs
@@ -34,7 +34,7 @@ goldens name fp action = goldenVsString name ("test/goldens/" ++ fp) $ runGitHub
       GitHubSettings
         { token = Nothing
         , userAgent = "github-rest"
-        , apiVersion = "v3"
+        , apiVersion = ""
         }
 
 showResult :: Monad m => m (Either Value Value) -> m ByteString


### PR DESCRIPTION
According to ["Media types"](https://docs.github.com/en/rest/overview/media-types?apiVersion=2022-11-28), the media type no longer needs to include the API version, and in fact, it will be ignored.  Instead, it is supposed to be specified in the [`X-GitHub-Api-Version`](https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28) HTTP header.  This change will make the media type always be `application/vnd.github+json`, and instead will include the API version in the HTTP header.  It will not set the HTTP header if `apiVersion` is empty.

This does not change the interface.  It would be nice to avoid having to deal with `apiVersion` if one does not intend to set it, but a user agent is supposedly required, so a `defaultSettings` function may not be the best approach.  I'm not sure what a good approach would be, or what you would like it to be, so this pull request ignores the issue for now.

Interestingly, `v3` is no longer a support version.  The tests will pass with `apiVersion` set to the string `2022-11-28`, but it seems less than ideal to have a test that will definitely start failing when this version is no longer supported.

This almost resolves https://github.com/LeapYear/github-rest/issues/32.