### PR TITLE
Bump time upper bound

### DIFF
--- a/github-rest.cabal
+++ b/github-rest.cabal
@@ -54,7 +54,7 @@ library
     , mtl <2.4
     , scientific <0.4
     , text <2.2
-    , time <1.13
+    , time <1.15
     , transformers <0.7
     , unliftio <0.3
     , unliftio-core <0.3

--- a/package.yaml
+++ b/package.yaml
@@ -42,7 +42,7 @@ library:
   - mtl < 2.4
   - scientific < 0.4
   - text < 2.2
-  - time < 1.13
+  - time < 1.15
   - transformers < 0.7
   - unliftio < 0.3
   - unliftio-core < 0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.3
+resolver: lts-22.13
 
 ghc-options:
   '$locals': -Werror

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 53a2800f7fe0c4628af0e7d5e985707dd3af9863ac3983a43c835dbaa8ed5f35
-    size: 714094
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/3.yaml
-  original: lts-22.3
+    sha256: 6f0bea3ba5b07360f25bc886e8cff8d847767557a492a6f7f6dcb06e3cc79ee9
+    size: 712905
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/13.yaml
+  original: lts-22.13


### PR DESCRIPTION
Tested with
```
cabal test --constraint 'time==1.14' --allow-newer='*:time'
```